### PR TITLE
Align Pollinations API calls with APIDOCS

### DIFF
--- a/chat-core.js
+++ b/chat-core.js
@@ -491,7 +491,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const modelSelectEl = document.getElementById("model-select");
         const model = modelSelectEl?.value || currentSession.model;
         if (!model) throw new Error("No model selected");
-        const apiUrl = `https://text.pollinations.ai/${encodeURIComponent(prompt)}?model=${encodeURIComponent(model)}`;
+        const apiUrl = `https://text.pollinations.ai/${encodeURIComponent(prompt)}?model=${encodeURIComponent(model)}&referrer=unityailab.com`;
 
         try {
             const res = await window.pollinationsFetch(apiUrl, {

--- a/chat-init.js
+++ b/chat-init.js
@@ -220,7 +220,6 @@ document.addEventListener("DOMContentLoaded", () => {
         const urlObj = new URL(img.src);
         const newSeed = Math.floor(Math.random() * 1000000);
         urlObj.searchParams.set("seed", newSeed);
-        urlObj.searchParams.set("nolog", "true");
         const newUrl = urlObj.toString();
         const loadingDiv = document.createElement("div");
         loadingDiv.className = "ai-image-loading";
@@ -602,7 +601,7 @@ document.addEventListener("DOMContentLoaded", () => {
         imagePrompt = imagePrompt.slice(0, 100) + ", photographic";
         const updateImage = () => {
             const seed = randomSeed();
-            voiceChatImage.src = `https://image.pollinations.ai/prompt/${encodeURIComponent(imagePrompt)}?width=512&height=512&seed=${seed}&nolog=true&referrer=unityailab.com`;
+            voiceChatImage.src = `https://image.pollinations.ai/prompt/${encodeURIComponent(imagePrompt)}?width=512&height=512&seed=${seed}&nologo=true&private=true&referrer=unityailab.com`;
         };
         updateImage();
         slideshowInterval = setInterval(updateImage, 10000);

--- a/chat-storage.js
+++ b/chat-storage.js
@@ -340,7 +340,6 @@ document.addEventListener("DOMContentLoaded", () => {
         const urlObj = new URL(img.src);
         const newSeed = Math.floor(Math.random() * 1000000);
         urlObj.searchParams.set('seed', newSeed);
-        urlObj.searchParams.set('nolog', 'true');
         const newUrl = urlObj.toString();
         const loadingDiv = document.createElement("div");
         loadingDiv.className = "ai-image-loading";
@@ -634,7 +633,7 @@ document.addEventListener("DOMContentLoaded", () => {
             const seed = Math.floor(Math.random() * 1000000);
             const imageId = `voice-img-${Date.now()}`;
             localStorage.setItem(`voiceImageId_${imageId}`, imageId);
-            const imageUrl = `https://image.pollinations.ai/prompt/${encodeURIComponent(imagePrompt)}?width=512&height=512&seed=${seed}&nolog=true&referrer=unityailab.com`;
+            const imageUrl = `https://image.pollinations.ai/prompt/${encodeURIComponent(imagePrompt)}?width=512&height=512&seed=${seed}&nologo=true&private=true&referrer=unityailab.com`;
             voiceChatImage.src = imageUrl;
             voiceChatImage.dataset.imageId = imageId;
             voiceChatImage.onload = () => {

--- a/screensaver.js
+++ b/screensaver.js
@@ -141,7 +141,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     async function fetchImageModels() {
         try {
-            const res = await window.pollinationsFetch("https://image.pollinations.ai/models", {
+            const res = await window.pollinationsFetch("https://image.pollinations.ai/models?referrer=unityailab.com", {
                 method: "GET",
                 headers: { "Content-Type": "application/json" },
                 cache: "no-store"
@@ -194,7 +194,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const metaPrompt = "Generate exactly one short-125-character, new, fucked up and explicit wild image prompt as text only of outlandish and psychologically thrilling image. i.e. demented, evil, psychotic photo.";
         const textModel = document.getElementById("model-select")?.value;
         const seed = generateSeed();
-        const apiUrl = `https://text.pollinations.ai/openai?${encodeURIComponent(metaPrompt)}?seed=${seed}&safe=false${textModel ? `&model=${encodeURIComponent(textModel)}` : ""}`;
+        const apiUrl = `https://text.pollinations.ai/${encodeURIComponent(metaPrompt)}?seed=${seed}${textModel ? `&model=${encodeURIComponent(textModel)}` : ""}&referrer=unityailab.com`;
         try {
             const response = await window.pollinationsFetch(apiUrl, {
                 method: "GET",
@@ -255,7 +255,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const enhance = settings.enhance;
         const priv = settings.priv;
 
-        const url = `https://image.pollinations.ai/prompt/${encodeURIComponent(prompt)}?width=${width}&height=${height}&seed=${seed}&model=${model}&nologo=true&private=${priv}&enhance=${enhance}&nolog=true&referrer=unityailab.com`;
+        const url = `https://image.pollinations.ai/prompt/${encodeURIComponent(prompt)}?width=${width}&height=${height}&seed=${seed}&model=${model}&nologo=true&private=${priv}&enhance=${enhance}&referrer=unityailab.com`;
         console.log("Generated new image URL:", url);
 
         const nextImage = currentImage === 'image1' ? 'image2' : 'image1';

--- a/simple.js
+++ b/simple.js
@@ -555,7 +555,6 @@ document.addEventListener("DOMContentLoaded", () => {
             const urlObj = new URL(img.src);
             const newSeed = Math.floor(Math.random() * 1000000);
             urlObj.searchParams.set('seed', newSeed);
-            urlObj.searchParams.set('nolog', 'true');
             const newUrl = urlObj.toString();
 
             const loadingDiv = document.createElement("div");

--- a/ui.js
+++ b/ui.js
@@ -110,7 +110,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     async function fetchPollinationsModels() {
         try {
-            const res = await window.pollinationsFetch("https://text.pollinations.ai/models", {
+            const res = await window.pollinationsFetch("https://text.pollinations.ai/models?referrer=unityailab.com", {
                 method: "GET",
                 headers: { "Content-Type": "application/json" },
                 cache: "no-store"


### PR DESCRIPTION
## Summary
- fix screensaver text prompt call to use path-based Pollinations endpoint and include referrer
- remove unsupported `nolog` parameter and use documented `nologo`/`private`
- add `referrer` query to Pollinations API requests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c65b21a9fc8329ad4596155f67448e